### PR TITLE
Inferrable Ship Payload Arity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-ship",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Composable, testable and typable side effects for Redux",
   "main": "dist/index.js",
   "scripts": {

--- a/src/ship.js
+++ b/src/ship.js
@@ -59,7 +59,7 @@ export function* getState<Effect, Commit, State, A>(
 
 export function* allAny<Effect, Commit, State>(
   ...ships: Ship<Effect, Commit, State, any>[]
-): Ship<Effect, Commit, State, any[]> {
+): Ship<Effect, Commit, State, *> {
   return yield {
     type: 'All',
     ships,


### PR DESCRIPTION
Original issue: #16 


As of 0.38, Flow now strictly enforces tuple arity, which causes an issue with the current typing of `allAny`

This PR sets the payload type of `allAny` to be inferred. 

I'm running flow 0.39, and this change removes errors on import.
